### PR TITLE
Je login and registration

### DIFF
--- a/src/scripts/Nutshell.js
+++ b/src/scripts/Nutshell.js
@@ -1,4 +1,4 @@
 export const Nutshell = () => {
     // Render all your UI components here
-    console.log("authenticated... nutshell has now been called")
+    console.log(`logged in to nutshell as user ${sessionStorage.getItem("activeUser")}`)
 }

--- a/src/scripts/Nutshell.js
+++ b/src/scripts/Nutshell.js
@@ -1,3 +1,4 @@
 export const Nutshell = () => {
     // Render all your UI components here
+    console.log("authenticated... nutshell has now been called")
 }

--- a/src/scripts/auth/LoginForm.js
+++ b/src/scripts/auth/LoginForm.js
@@ -36,6 +36,7 @@ eventHub.addEventListener("click", e => {
 const render = () => {
     contentTarget.innerHTML += `
         <section class="login">
+            <h2 class="login__header">Login to an Existing Account</h2>
             <input id="login--username" type="text" placeholder="Enter your username">
             <input id="login--password" type="password" placeholder="Enter your password">
 

--- a/src/scripts/auth/LoginForm.js
+++ b/src/scripts/auth/LoginForm.js
@@ -21,6 +21,12 @@ eventHub.addEventListener("click", e => {
                         sessionStorage.setItem("activeUser", user.id)
                         eventHub.dispatchEvent(new CustomEvent("userAuthenticated"))
                     }
+                    else {
+                        renderLoginError()
+                    }
+                }
+                else {
+                    renderLoginError()
                 }
             })
     }
@@ -36,6 +42,10 @@ const render = () => {
             <button id="login--button">Log In</button>
         </section>
     `
+}
+
+const renderLoginError = () => {
+    window.alert("The username and/or password provided does not match our records.")
 }
 
 export const LoginForm = () => {

--- a/src/scripts/auth/RegisterForm.js
+++ b/src/scripts/auth/RegisterForm.js
@@ -58,6 +58,7 @@ eventHub.addEventListener("click", e => {
 const render = () => {
     contentTarget.innerHTML += `
         <section class="register">
+            <h2 class="register__header">Register a New Account</h2>
             <input id="register--username" type="text" placeholder="Enter your username">
             <input id="register--email" type="text" placeholder="Enter your email address">
             <input id="register--password" type="password" placeholder="Enter your password">

--- a/src/scripts/auth/RegisterForm.js
+++ b/src/scripts/auth/RegisterForm.js
@@ -48,6 +48,9 @@ eventHub.addEventListener("click", e => {
                 }
             })
         }
+        else {
+            window.alert("All registration fields must be filled out and passwords must match!")
+        }
     }
 })
 

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -2,6 +2,7 @@ import { LoginForm } from "./auth/LoginForm.js"
 import { RegisterForm } from "./auth/RegisterForm.js"
 import { Nutshell } from "./Nutshell.js"
 
+const eventHub = document.querySelector(".container")
 
 /*
     1. Check if the user is authenticated by looking in session storage for `activeUser`
@@ -10,3 +11,13 @@ import { Nutshell } from "./Nutshell.js"
     4. Also, if the user authenticates, and the login form is initially shown
         ensure that the Nutshell component gets rendered
 */
+
+eventHub.addEventListener("userAuthenticated", Nutshell) 
+
+if(sessionStorage.getItem("activeUser")) {
+    Nutshell()
+}
+else {
+    LoginForm()
+    RegisterForm()
+}


### PR DESCRIPTION
1. Create a "users" property in your array in api/database.json, and set it to an array, `"users": []`. Make sure you are json-serving your database.
1. Run through the test cases in Epic Card #13. You can currently verify a successful login by a) the login/register forms will disappear, and b) the ID of the currently logged-in user will be console.logged when the user logs in, or on any subsequent navigations to Nutshell in the same tab after having logged in. Eventually we'll probably want to get rid of this console.log in `Nutshell.js` when we start rendering components there, but for testing purposes for now it is maybe helpful.
1. Verify that some helpful validation/feedback has been added to the login/registration forms that will cause a `window.alert` if the user leaves any fields blank or has non-matching passwords in registration form, or if they provide any login credentials that don't match an existing user object in the database in the login form.