### PR TITLE
you cannot submit an empty message to the chat anymore

### DIFF
--- a/src/scripts/Messages/MessageForm.js
+++ b/src/scripts/Messages/MessageForm.js
@@ -5,10 +5,15 @@ const eventHub = document.querySelector(".container")
 eventHub.addEventListener("click", event => {
   if(event.target.id === "saveMessage") {
     const messageData = {
-      message: document.querySelector(".messageForm__message").value
+      message: document.querySelector(".messageForm__message").value.trim()
     }
 
-    saveMessage(messageData)
+    if(messageData.message) {
+      saveMessage(messageData)
+    }
+    else {
+      window.alert("You cannot submit an empty chat message.")
+    }
   }
 })
 


### PR DESCRIPTION
1. Verify that the browser alerts if you try to submit a chat message with no text (either empty or just whitespace).
1. Verify that you can still submit a chat message with text.