### PR TITLE
Je private messages

### DIFF
--- a/src/scripts/Friends/FriendList.js
+++ b/src/scripts/Friends/FriendList.js
@@ -1,7 +1,7 @@
 /* Esther Sanders ... renders the friend list for current activeUser, listens for friendStateChanged and re-renders when new friend is added or deleted
 also includes HTML converter function */
 
-import { getFriends, useFriends, saveFriend, deleteFriend } from "./FriendDataProvider.js"
+import { getFriends, useFriends, deleteFriend } from "./FriendDataProvider.js"
 import { getUsers, useUsers } from "../Users/UserDataProvider.js"
 
 const contentTarget = document.querySelector(".friendsContainer")
@@ -49,13 +49,22 @@ eventHub.addEventListener("click", clickEvent => {
             })
         
     }
+    else if(clickEvent.target.id.startsWith("friendList__friend--")) {
+        const userId = parseInt(clickEvent.target.id.split("--")[1])
+        const friendSelectedEvent = new CustomEvent("friendSelected", {
+            detail: {
+                friendId: userId
+            }
+        })
+        eventHub.dispatchEvent(friendSelectedEvent)
+    }
 })
 
 const FriendsHTMLConverter = (users) => {
     return `
     ${
         users.map(user => {
-            return `<div>${user.username}</div>
+            return `<div id="friendList__friend--${user.id}" class="friendList__friend">${user.username}</div>
                     <button id="deleteFriend--${user.id}">Delete Friend</button>`
         })
     }

--- a/src/scripts/Messages/MessageDataProvider.js
+++ b/src/scripts/Messages/MessageDataProvider.js
@@ -20,8 +20,23 @@ export const getMessages = () => {
 export const usePublicMessages = () => {
   return messages
     .slice()
-    .sort((currentMessage, nextMessage) => currentMessage.timestamp - nextMessage.timestamp)
     .filter(message => !message.recipientId)
+    .sort((currentMessage, nextMessage) => currentMessage.timestamp - nextMessage.timestamp)
+}
+
+export const usePrivateMessagesWithUser = userId => {
+  return messages
+    .filter((message) => isPrivateMessageBetweenActiveUserAndUser(message, userId))
+    .sort((currentMessage, nextMessage) => currentMessage.timestamp - nextMessage.timestamp)
+}
+
+const isPrivateMessageBetweenActiveUserAndUser = (message, userId) => {
+  const activeUserId = parseInt(sessionStorage.getItem("activeUser"))
+
+  return (
+    (message.userId === activeUserId && message.recipientId === userId) ||
+    (message.userId === userId && message.recipientId === activeUserId)
+  )
 }
 
 export const saveMessage = (messageData, recipientId = null) => {

--- a/src/scripts/Messages/MessageDataProvider.js
+++ b/src/scripts/Messages/MessageDataProvider.js
@@ -17,17 +17,19 @@ export const getMessages = () => {
     .then(messagesData => messages = messagesData)
 }
 
-export const useMessages = () => {
+export const usePublicMessages = () => {
   return messages
     .slice()
     .sort((currentMessage, nextMessage) => currentMessage.timestamp - nextMessage.timestamp)
+    .filter(message => !message.recipientId)
 }
 
-export const saveMessage = messageData => {
+export const saveMessage = (messageData, recipientId = null) => {
   const messageObj = {
     message: messageData.message,
     timestamp: Date.now(),
-    userId: parseInt(sessionStorage.getItem("activeUser"))
+    userId: parseInt(sessionStorage.getItem("activeUser")),
+    recipientId: recipientId
   }
 
   return fetch("http://localhost:8088/messages", {

--- a/src/scripts/Messages/MessageDataProvider.js
+++ b/src/scripts/Messages/MessageDataProvider.js
@@ -39,12 +39,12 @@ const isPrivateMessageBetweenActiveUserAndUser = (message, userId) => {
   )
 }
 
-export const saveMessage = (messageData, recipientId = null) => {
+export const saveMessage = messageData => {
   const messageObj = {
     message: messageData.message,
+    recipientId: messageData.recipientId,
     timestamp: Date.now(),
-    userId: parseInt(sessionStorage.getItem("activeUser")),
-    recipientId: recipientId
+    userId: parseInt(sessionStorage.getItem("activeUser"))
   }
 
   return fetch("http://localhost:8088/messages", {

--- a/src/scripts/Messages/MessageForm.js
+++ b/src/scripts/Messages/MessageForm.js
@@ -8,9 +8,7 @@ eventHub.addEventListener("click", event => {
 
     const id = event.target.id.split("--")[1] // will be empty string if new message, or id of message we are editing if editing message
 
-    const messageObj = {
-      message: document.querySelector(`#messageForm__message--${id}`).value.trim()
-    }
+    const messageObj = createMessageObjectFromFormValues(id)
 
     if(validateMessage(messageObj)) {
       if(id) {
@@ -25,15 +23,42 @@ eventHub.addEventListener("click", event => {
 
 // return the HTML for a form with optional default values set in messageObj param
 export const MessageForm = messageObj => {
-  const defaultMessageValue = messageObj ? messageObj.message : ""
-  const idValue = messageObj ? messageObj.id : ""
+  const defaultValues = getDefaultValues(messageObj)
+  const { message, id, recipientId } = defaultValues
 
   return `
     <div class="messageForm">
-      <textarea class="messageForm__message" id="messageForm__message--${idValue}" placeholder="Enter a message">${defaultMessageValue}</textarea>
-      <button id="saveMessage--${idValue}">${idValue ? "Update" : "Send"} Message</button>
+      <textarea class="messageForm__message" id="messageForm__message--${id}" placeholder="Enter a message">${message}</textarea>
+      <input type="hidden" id="messageForm__recipientId--${id}" value="${recipientId}">
+      <button id="saveMessage--${id}">${id ? "Update" : "Send"} Message</button>
     </div>
   `
+}
+
+// given a message obj, get DOM-friendly optional default values (e.g., if some property is not defined in the messageObj passed in, return empty string instead of "undefined")
+const getDefaultValues = messageObj => {
+  const defaultValues = {}
+
+  if(messageObj) {
+    defaultValues.message = messageObj.message || ""
+    defaultValues.id = messageObj.id || ""
+    defaultValues.recipientId = messageObj.recipientId ? messageObj.recipientId : ""
+  }
+
+  return defaultValues
+}
+
+// create a message object from the values in the form identified by id (if id empty string, represents new message form, if set to an id represents the id of the message that is being edited)
+const createMessageObjectFromFormValues = id => {
+  const messageNode = document.querySelector(`#messageForm__message--${id}`)
+  const recipientIdNode = document.querySelector(`#messageForm__recipientId--${id}`)
+
+  const messageObj = {
+    message: messageNode.value.trim(),
+    recipientId: recipientIdNode.value ? parseInt(recipientIdNode.value) : null
+  }
+
+  return messageObj
 }
 
 // validate a message - if invalid do an error alert and return false. otherwise return true

--- a/src/scripts/Messages/MessageList.js
+++ b/src/scripts/Messages/MessageList.js
@@ -1,4 +1,4 @@
-import { getMessages, useMessages } from "./MessageDataProvider.js"
+import { getMessages, usePublicMessages } from "./MessageDataProvider.js"
 import { Message } from "./Message.js"
 import { MessageForm } from "./MessageForm.js"
 
@@ -12,7 +12,7 @@ let currentScrollPos = null
 
 // react to a state change of messages, handle re-rendering the list with new messages state, scrolling the list to where it should most user-friendly-ly be scrolled to, and unsetting the currently-editing message ID if state change represents a new edit
 eventHub.addEventListener("messagesStateChanged", event => {
-  messages = useMessages()
+  messages = usePublicMessages()
   const stateChangeDescription = event.detail.stateChangeDescription
 
   switch(stateChangeDescription) {
@@ -42,7 +42,7 @@ eventHub.addEventListener("editMessageButtonClicked", event => {
 export const MessageList = () => {
   getMessages()
     .then(() => {
-      messages = useMessages()
+      messages = usePublicMessages()
       render()
       scrollToBottom()
     })

--- a/src/scripts/Messages/MessageList.js
+++ b/src/scripts/Messages/MessageList.js
@@ -1,4 +1,4 @@
-import { getMessages, usePublicMessages } from "./MessageDataProvider.js"
+import { getMessages, usePublicMessages, usePrivateMessagesWithUser } from "./MessageDataProvider.js"
 import { Message } from "./Message.js"
 import { MessageForm } from "./MessageForm.js"
 
@@ -9,10 +9,11 @@ let messages = []
 
 let editingMessageId = null
 let currentScrollPos = null
+let selectedFriendId = null
 
 // react to a state change of messages, handle re-rendering the list with new messages state, scrolling the list to where it should most user-friendly-ly be scrolled to, and unsetting the currently-editing message ID if state change represents a new edit
 eventHub.addEventListener("messagesStateChanged", event => {
-  messages = usePublicMessages()
+  messages = updateMessagesState()
   const stateChangeDescription = event.detail.stateChangeDescription
 
   switch(stateChangeDescription) {
@@ -46,6 +47,29 @@ export const MessageList = () => {
       render()
       scrollToBottom()
     })
+}
+
+eventHub.addEventListener("friendSelected", event => {
+  const friendId = event.detail.friendId
+
+  if(selectedFriendId === friendId) {
+    selectedFriendId = null
+  }
+  else {
+    selectedFriendId = friendId
+  }
+
+  updateMessagesState()
+  render()
+})
+
+const updateMessagesState = () => {
+  if(selectedFriendId) {
+    messages = usePrivateMessagesWithUser(selectedFriendId)
+  }
+  else {
+    messages = usePublicMessages()
+  }
 }
 
 const render = () => {

--- a/src/scripts/Messages/MessageList.js
+++ b/src/scripts/Messages/MessageList.js
@@ -1,4 +1,5 @@
 import { getMessages, usePublicMessages, usePrivateMessagesWithUser } from "./MessageDataProvider.js"
+import { useUsers } from "../Users/UserDataProvider.js"
 import { Message } from "./Message.js"
 import { MessageForm } from "./MessageForm.js"
 
@@ -13,7 +14,7 @@ let selectedFriendId = null
 
 // react to a state change of messages, handle re-rendering the list with new messages state, scrolling the list to where it should most user-friendly-ly be scrolled to, and unsetting the currently-editing message ID if state change represents a new edit
 eventHub.addEventListener("messagesStateChanged", event => {
-  messages = updateMessagesState()
+  updateMessagesState()
   const stateChangeDescription = event.detail.stateChangeDescription
 
   switch(stateChangeDescription) {
@@ -49,6 +50,7 @@ export const MessageList = () => {
     })
 }
 
+// handle user having selected a friend. update messages state to only be those private messages between the activeUser and the selected user, rerender with only these messages
 eventHub.addEventListener("friendSelected", event => {
   const friendId = event.detail.friendId
 
@@ -61,8 +63,10 @@ eventHub.addEventListener("friendSelected", event => {
 
   updateMessagesState()
   render()
+  scrollToBottom()
 })
 
+// update component-state messages array - if no selectedFriendId is set that means we want public chat messages and thus usePublicMessage(), otherwise we should update component state messages to be the messages between the activeUser and the selected user
 const updateMessagesState = () => {
   if(selectedFriendId) {
     messages = usePrivateMessagesWithUser(selectedFriendId)
@@ -73,7 +77,18 @@ const updateMessagesState = () => {
 }
 
 const render = () => {
+  let headerMessage;
+
+  if(selectedFriendId) {
+    const selectedUser = useUsers().find(user => user.id === selectedFriendId)
+    headerMessage = `Private Chat with ${selectedUser.username}`
+  }
+  else {
+    headerMessage = "Public Chat"
+  }
+
   contentTarget.innerHTML = `
+    <h3 class="messageList__header">${headerMessage}</h3>
     <div class="messageList">
       ${ messages.map(message => {
 
@@ -86,7 +101,7 @@ const render = () => {
         return Message(message)
 
       }).join("") }
-      ${ MessageForm() }
+      ${ MessageForm({ recipientId: selectedFriendId }) }
     </div>
   `
 


### PR DESCRIPTION
1. Delete ALL of your messages in `database.json` before testing!!! The message data structure slightly changed (there is now a `recipientId` property on messages which, if null, indicates the message is a public message, or otherwise if set to a userId indicates the message is a private message from message.userId to message.recipientId).
1. Verify that on page load, the message list is empty... because you just deleted all your messages. But it should say "Public Chat" at the top now.
1. Verify that "Public Chat" continues to work exactly as it always has by posting new chat messages as different users, making sure all users see them, making sure all the functionality is still there.
1. Verify that if you click on a username in the Friend List component, the Message List will then update to show only the private messages between these two users, and will have a fitting header of "Private Chat with <the username that you clicked on>".
1. As User X, send a private message to User Y. Then, log into User Y's account. Open your private messages with User X as User Y (you have to be friends both ways for this to work, as you can only access private messages by clicking on a friend in the friend list). Make sure that you see the private message you sent as User X in User Y's private chat history with User X.
1. Test that all the functionality still works fine in a private message list as well (e.g., a user can still edit their own private messages, delete their own private messages).
1. Finally, by clicking on the username of the user that you are currently private messaging in the friend list, verify that the message list turns back into the public chat board.

One thing that this does not handle that we may want to consider adding as an enhancement: if User X has opened their private messages with User Y, and then User X deletes User Y from their friend list, there is basically no way to get back to the public chat b/c User X can't click on User Y in their friend list anymore.