### PR TITLE
Je private messages with delete friend

### DIFF
--- a/src/scripts/Messages/MessageList.js
+++ b/src/scripts/Messages/MessageList.js
@@ -2,6 +2,7 @@ import { getMessages, usePublicMessages, usePrivateMessagesWithUser } from "./Me
 import { useUsers } from "../Users/UserDataProvider.js"
 import { Message } from "./Message.js"
 import { MessageForm } from "./MessageForm.js"
+import { useFriends } from "../Friends/FriendDataProvider.js"
 
 const eventHub = document.querySelector(".container")
 const contentTarget = document.querySelector(".chatContainer")
@@ -64,6 +65,18 @@ eventHub.addEventListener("friendSelected", event => {
   updateMessagesState()
   render()
   scrollToBottom()
+})
+
+// if friend state changed such that the active user is no longer friends with the selected user they are private chatting, set message list back to public chat state
+eventHub.addEventListener("friendStateChanged", () => {
+  const friends = useFriends()
+  const activeUserId = parseInt(sessionStorage.getItem("activeUser"))
+  if(!friends.some(friend => friend.activeUserId === activeUserId && friend.userId === selectedFriendId)) {
+    selectedFriendId = null
+    updateMessagesState()
+    render()
+    scrollToBottom() 
+  }
 })
 
 // update component-state messages array - if no selectedFriendId is set that means we want public chat messages and thus usePublicMessage(), otherwise we should update component state messages to be the messages between the activeUser and the selected user

--- a/src/scripts/Messages/MessageList.js
+++ b/src/scripts/Messages/MessageList.js
@@ -116,6 +116,7 @@ const render = () => {
     </div>
   `
 
+  // after rendering the list, scroll the list to the scroll position saved in currentScrollPos, or to the bottom of the list
   scrollToTargetScrollPosition()
 
   // add scroll event listener to messageList after putting it on the dom, keep track of where the list is scrolled to
@@ -124,7 +125,7 @@ const render = () => {
   })
 }
 
-// scroll the list to the last scroll position it was scrolled to saved in component-state currentScrollPos variable, or if currentScrollPos is null scroll to bottom of list
+// scroll the list to the last scroll position it was scrolled to (saved in component-state currentScrollPos variable), or if currentScrollPos is null scroll to bottom of list
 const scrollToTargetScrollPosition = () => {
   const messageList = document.querySelector(".messageList")
   if(currentScrollPos === null) {


### PR DESCRIPTION
Fix for #101 

Verify that if you click on a user in the friend list so that message list becomes private messages with that user, then delete that user as your friend, the message list reverts back to public chat. Verify that this only happens if you specifically delete the user that you are chatting with as your friend, and not if you delete any other user as a friend while private chatting someone.