### PR TITLE
Je implement private chat correctly

### DIFF
--- a/src/scripts/Friends/FriendDataProvider.js
+++ b/src/scripts/Friends/FriendDataProvider.js
@@ -56,3 +56,7 @@ export const deleteFriend = (friend) => {
         .then(dispatchStateChangeEvent)
 }
 
+export const isFriendWithActiveUser = userId => {
+    const activeUserId = parseInt(sessionStorage.getItem("activeUser"))
+    return friends.some(friend => friend.activeUserId === activeUserId && friend.userId === userId)
+}

--- a/src/scripts/Messages/MessageForm.js
+++ b/src/scripts/Messages/MessageForm.js
@@ -77,6 +77,14 @@ const getRecipientId = (message, recipientId) => {
     const username = message.split(' ')[0].substring(1)
     const user = useUserByName(username)
     if(user && isFriendWithActiveUser(user.id)) {
+      // user has initiated private chat with a specific user via the chat interface - switch over to private chat view with that user
+      const initiatedPrivateChatEvent = new CustomEvent("initiatedPrivateChat", {
+        detail: {
+          userId: user.id
+        }
+      })
+      eventHub.dispatchEvent(initiatedPrivateChatEvent)
+
       return user.id
     }
   }

--- a/src/scripts/Messages/MessageForm.js
+++ b/src/scripts/Messages/MessageForm.js
@@ -1,6 +1,8 @@
 // Jacob Eckert - module to handle creating the HTML for a Message Form. Handles a message form both in the context of creating a new message and editing an existing message. Handles a message form both in the context of creating/editing a public chat message and creating/editing a private message.
 
 import { saveMessage, updateMessage } from "./MessageDataProvider.js"
+import { useUserByName } from "../Users/UserDataProvider.js"
+import { isFriendWithActiveUser } from "../Friends/FriendDataProvider.js"
 
 const eventHub = document.querySelector(".container")
 
@@ -55,12 +57,35 @@ const createMessageObjectFromFormValues = id => {
   const messageNode = document.querySelector(`#messageForm__message--${id}`)
   const recipientIdNode = document.querySelector(`#messageForm__recipientId--${id}`)
 
+  let message = messageNode.value.trim()
+  const recipientId = getRecipientId(message, recipientIdNode.value)
+
+  if(message.startsWith("@")) {
+    message = message.split(" ").slice(1).join(" ")
+  }
+
   const messageObj = {
-    message: messageNode.value.trim(),
-    recipientId: recipientIdNode.value ? parseInt(recipientIdNode.value) : null
+    message: message,
+    recipientId: recipientId
   }
 
   return messageObj
+}
+
+const getRecipientId = (message, recipientId) => {
+  if(message.startsWith("@")) {
+    const username = message.split(' ')[0].substring(1)
+    const user = useUserByName(username)
+    if(user && isFriendWithActiveUser(user.id)) {
+      return user.id
+    }
+  }
+
+  if(recipientId) {
+    return parseInt(recipientId)
+  }
+
+  return null
 }
 
 // validate a message - if invalid do an error alert and return false. otherwise return true

--- a/src/scripts/Messages/MessageList.js
+++ b/src/scripts/Messages/MessageList.js
@@ -65,6 +65,17 @@ eventHub.addEventListener("friendSelected", event => {
   render()
 })
 
+// handle user having initiated private chat with a friend (via @friend_user_name in the public chat) - set currentFriendId to the id of the user private chat was initiated with and re-render
+eventHub.addEventListener("initiatedPrivateChat", event => {
+  const userId = event.detail.userId
+
+  selectedFriendId = userId
+
+  updateMessagesState()
+  currentScrollPos = null
+  render()
+})
+
 // if friend state changed such that the active user is no longer friends with the selected user they are private chatting, set message list back to public chat state
 eventHub.addEventListener("friendStateChanged", () => {
   if(selectedFriendId) {

--- a/src/scripts/Users/UserDataProvider.js
+++ b/src/scripts/Users/UserDataProvider.js
@@ -13,5 +13,5 @@ export const useUsers = () => {
 }
 
 export const useUserByName = username => {
-    return users.find(user => user.username === username)
+    return users.find(user => user.username.toLowerCase() === username.toLowerCase())
 }

--- a/src/scripts/Users/UserDataProvider.js
+++ b/src/scripts/Users/UserDataProvider.js
@@ -11,3 +11,7 @@ export const getUsers = () => {
 export const useUsers = () => {
     return users.slice()
 }
+
+export const useUserByName = username => {
+    return users.find(user => user.username === username)
+}


### PR DESCRIPTION
I totally failed to see that there were acceptance criteria explicitly listed for #2 haaaaa, so this pull request implements the "@" feature.

Verify that if you prepend a chat message with @ and then type in the username of a user that you are friends with, after you submit the message that message will go through as a private chat message to that user, and you will swap over to the private chat with that user view as well. Verify that, as before, only the user that a private chat message was sent to can see that message (first have to click on the friend that sent the message in the friend list so as to view your private chat messages with that user).

I made it so that if you type in an @ and then either a username that doesn't exist or a user that you aren't friends with, that the message will just go through as a public message. 